### PR TITLE
[#3] Include Cache-Control header in HEAD requests

### DIFF
--- a/src/org/akvo/resumed.clj
+++ b/src/org/akvo/resumed.clj
@@ -59,7 +59,8 @@
        :headers (assoc tus-headers
                        "Upload-Offset" (str (:offset found))
                        "Upload-Length" (str (:length found))
-                       "Upload-Metadata" (:metadata found))}
+                       "Upload-Metadata" (:metadata found)
+                       "Cache-Control" "no-cache")}
       {:status 404
        :body "Not Found"})))
 

--- a/test/org/akvo/resumed_test.clj
+++ b/test/org/akvo/resumed_test.clj
@@ -81,7 +81,8 @@
       (is (= 200 (:status resp)))
       (is (= (str len) (get-in resp [:headers "Upload-Length"])))
       (is (= um (get-in resp [:headers "Upload-Metadata"])))
-      (is (= "0" (get-in resp [:headers "Upload-Offset"]))))))
+      (is (= "0" (get-in resp [:headers "Upload-Offset"])))
+      (is (= "no-cache" (get-in resp [:headers "Cache-Control"]))))))
 
 (deftest patch-single-request
   (let [handler (make-handler)


### PR DESCRIPTION
Include `Cache-Control: no-cache` in `HEAD` requests based on protocol definition