### PR TITLE
[#8] If exists use origin as location

### DIFF
--- a/src/org/akvo/resumed.clj
+++ b/src/org/akvo/resumed.clj
@@ -125,7 +125,6 @@
   It attempts to honor: X-Forwared-Host, Origin, Host headers"
   [req]
   (or (get-header req "x-forwarded-host")
-      (get-header req "origin")
       (some-> req (get-header "host") (.split ":") first)
       (:server-name req)))
 
@@ -161,7 +160,8 @@
 (defn location
   "Get Location string from request"
   [req]
-  (format "%s://%s%s%s" (protocol req) (host req) (port req) (:uri req)))
+  (or (some-> req (get-header "origin") (str (:uri req)))
+      (format "%s://%s%s%s" (protocol req) (host req) (port req) (:uri req))))
 
 (defn post
   [req {:keys [save-path upload-cache max-upload-size]}]

--- a/test/org/akvo/resumed_test.clj
+++ b/test/org/akvo/resumed_test.clj
@@ -1,13 +1,13 @@
 (ns org.akvo.resumed-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
             [org.akvo.resumed :refer :all]
-            [ring.mock.request :as m]
-            [clojure.java.io :as io]
-            [ring.adapter.jetty :as jetty])
-  (:import java.io.File
-           java.net.URL
-           [io.tus.java.client TusClient TusUpload
-                               TusUploader TusURLMemoryStore]))
+            [ring.adapter.jetty :as jetty]
+            [ring.mock.request :as m])
+  (:import [io.tus.java.client TusClient TusUpload
+            TusUploader TusURLMemoryStore]
+           java.io.File
+           java.net.URL))
 
 (defn res-to-byte-array
   "Reads a resource file to a byte array
@@ -232,7 +232,13 @@
       "https://some.tld:8443/path" {:headers {"host" "some.tld"}
                                     :uri "/path"
                                     :server-port 8443
-                                    :scheme :https})))
+                                    :scheme :https}
+      "http://t1.lumen.local:3030/api/files" {:headers {"host" "t1.lumen.local:3030"
+                                                        "origin" "http://t1.lumen.local:3030"}
+                                              :uri "/api/files"
+                                              :server-port 3000
+                                              :scheme :http})))
+
 
 (deftest check-upload-length
   (testing "Restrict the number of PATCH requests to the Upload-Length"


### PR DESCRIPTION
Chrome sends the full location (with protocol and port) as origin.